### PR TITLE
Fix typesafe session attributes feature

### DIFF
--- a/clova-cek-sdk-csharp.tests/Models/CEKRequestTest.cs
+++ b/clova-cek-sdk-csharp.tests/Models/CEKRequestTest.cs
@@ -35,32 +35,6 @@ namespace CEK.CSharp.Tests.Models
             Assert.Null(target.GetSessionAttributeAs<SessionType>());
         }
 
-        [Fact]
-        public void TypeSafeWriteSessionAttributeTest()
-        {
-            var target = new CEKRequest
-            {
-                Session = new Session(),
-            };
-            var sessionValue = new SessionType
-            {
-                A = "a value",
-                B = "b value",
-            };
-
-            target.SetSessionAttributeFrom(sessionValue);
-            Assert.Equal("a value", (string)target.GetSessionAttribute("A"));
-            Assert.Equal("b value", (string)target.GetSessionAttribute("B"));
-        }
-
-        [Fact]
-        public void TypeSafeWriteSessionAttributeNullCaseTest()
-        {
-            var target = new CEKRequest();
-            target.SetSessionAttributeFrom(default(SessionType));
-            Assert.Null(target.Session.SessionAttributes);
-        }
-
         class SessionType
         {
             public string A { get; set; }

--- a/clova-cek-sdk-csharp.tests/Models/CEKResponseTest.cs
+++ b/clova-cek-sdk-csharp.tests/Models/CEKResponseTest.cs
@@ -1,0 +1,40 @@
+﻿using CEK.CSharp.Models;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Xunit;
+
+namespace CEK.CSharp.Tests.Models
+{
+    public class CEKResponseTest
+    {
+        [Fact]
+        public void TypeSafeSessionAttributeSetTest()
+        {
+            var sessionValue = new OrderInfo
+            {
+                MenuName = "Pizza",
+                OrderCount = 10,
+            };
+            var response = new CEKResponse();
+            response.SetSessionAttributesFrom(sessionValue);
+            Assert.Equal("Pizza", (string)response.SessionAttributes["MenuName"]);
+            Assert.Equal(10, (long)response.SessionAttributes["OrderCount"]);
+        }
+
+        [Fact]
+        public void TypeSafeSessionAttributeSetNullTest()
+        {
+            var response = new CEKResponse();
+            response.AddSession("dummy", "dummy");
+            response.SetSessionAttributesFrom(null);
+            Assert.Empty(response.SessionAttributes);
+        }
+    }
+
+    public class OrderInfo
+    {
+        public string MenuName { get; set; }
+        public long OrderCount { get; set; }
+    }
+}

--- a/clova-cek-sdk-csharp/Models/CEKRequest.cs
+++ b/clova-cek-sdk-csharp/Models/CEKRequest.cs
@@ -59,28 +59,5 @@ namespace CEK.CSharp.Models
 
             return JsonConvert.DeserializeObject<T>(JsonConvert.SerializeObject(Session.SessionAttributes));
         }
-
-        /// <summary>
-        /// セッション情報をタイプセーフな型で設定する。
-        /// </summary>
-        /// <typeparam name="T">セッション情報の型</typeparam>
-        /// <param name="sessionValue">セッション情報</param>
-        public void SetSessionAttributeFrom<T>(T sessionValue)
-            where T : class
-        {
-            if (Session == null)
-            {
-                Session = new Session();
-            }
-
-            if (sessionValue == null)
-            {
-                Session.SessionAttributes = null;
-            }
-            else
-            {
-                Session.SessionAttributes = JsonConvert.DeserializeObject<Dictionary<string, object>>(JsonConvert.SerializeObject(sessionValue));
-            }
-        }
     }
 }

--- a/clova-cek-sdk-csharp/Models/CEKResponse.cs
+++ b/clova-cek-sdk-csharp/Models/CEKResponse.cs
@@ -229,5 +229,19 @@ namespace CEK.CSharp.Models
                 Value = url
             });
         }
+
+        /// <summary>
+        /// クラスの情報を SessionAttributes に設定する。
+        /// </summary>
+        /// <param name="sessionValue">セッション情報</param>
+        public void SetSessionAttributesFrom(object sessionValue)
+        {
+            SessionAttributes.Clear();
+            if (sessionValue != null)
+            {
+                JsonConvert.PopulateObject(JsonConvert.SerializeObject(sessionValue), SessionAttributes);
+            }
+        }
+
     }
 }


### PR DESCRIPTION
Hi, @kenakamu ,

I made a mistake at the previous pull request.
I should have added `SetSessionAttributesFrom` method on `CEKResponse` class. 
However, I had added the method to `CEKRequest` class.

This pull request is for fixing that.
